### PR TITLE
Use @now/static-build to initiate Parcel build.

### DIFF
--- a/now.json
+++ b/now.json
@@ -1,6 +1,6 @@
 {
   "version": 2,
   "builds": [
-    { "src": "index.html", "use": "now-parcel" }
+    { "src": "package.json", "use": "@now/static-build" }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "parcel-bundler": "^1.10.3"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "now-build": "parcel build index.html"
   },
   "author": "",
   "license": "AGPL-3.0"


### PR DESCRIPTION
See: https://zeit.co/docs/v2/deployments/official-builders/static-build-now-static-build/

I'm a bit wary of using an unofficial now builder, so I'm doing it "manually" using "now-build" script in package.json.