### PR TITLE
Double type vowels to get a long vowel

### DIFF
--- a/cypress/integration/gh-008-double-vowels.js
+++ b/cypress/integration/gh-008-double-vowels.js
@@ -1,0 +1,19 @@
+/**
+ * Test double-typing to insert long vowels.
+ */
+describe('Double typing for long vowels', function () {
+  it('should work by typing the same vowel twice', function () {
+    cy.visit('/');
+
+    cy.get('textarea#sro')
+      .clear()
+      .type("eetii niiya, ekwa oohoo niciihkeyimaaw");
+
+    cy.get('textarea#sro')
+      .invoke('val')
+      .should('equal', 'ᐁᑏ ᓃᔭ, ᐁᑿ ᐆᐦᐆ ᓂᒌᐦᑫᔨᒫᐤ')
+  });
+
+  it.skip('should not affect pasted text');
+  it.skip('can be disabled');
+});

--- a/cypress/integration/gh-008-double-vowels.js
+++ b/cypress/integration/gh-008-double-vowels.js
@@ -7,17 +7,41 @@ describe('Double typing for long vowels', function () {
 
     cy.get('textarea#sro')
       .clear()
+    // type double vowels here:
       .type('eetii niiya, eekwa oohoo niciihkeeyimaaw.');
 
+    // it should convert properly
     cy.get('textarea#syl')
       .invoke('val')
       .should('equal', 'ᐁᑏ ᓃᔭ, ᐁᑿ ᐆᐦᐆ ᓂᒌᐦᑫᔨᒫᐤ᙮')
 
+    // ...and the results should be reflected in the original buffer.
     cy.get('textarea#sro')
       .invoke('val')
       .should('contain', 'êtî nîya, êkwa ôhô nicîhkêyimâw.');
   });
 
-  it.skip('should not affect pasted text');
+  it('should not affect pasted text', function () {
+    cy.get('textarea#sro').as('sro');
+    var insertedText = 'mitho-ociimi-kiisikanisik';
+
+    // Typing out the text should replace double vowels.
+    cy.get('@sro')
+      .clear()
+      .type(insertedText)
+      .invoke('val')
+      .should('not.contain', insertedText)
+      .and('contains', 'mitho-ocîmi-kîsikanisik');
+
+    // Pretend to paste text into the box:
+    cy.get('@sro')
+      .clear()
+      .invoke('val', insertedText)
+      .trigger('input')
+    // However, this should NOT change the buffer!
+      .invoke('val')
+      .should('contain', insertedText);
+  });
+
   it.skip('can be disabled');
 });

--- a/cypress/integration/gh-008-double-vowels.js
+++ b/cypress/integration/gh-008-double-vowels.js
@@ -7,11 +7,15 @@ describe('Double typing for long vowels', function () {
 
     cy.get('textarea#sro')
       .clear()
-      .type("eetii niiya, ekwa oohoo niciihkeyimaaw");
+      .type('eetii niiya, eekwa oohoo niciihkeeyimaaw.');
+
+    cy.get('textarea#syl')
+      .invoke('val')
+      .should('equal', 'ᐁᑏ ᓃᔭ, ᐁᑿ ᐆᐦᐆ ᓂᒌᐦᑫᔨᒫᐤ᙮')
 
     cy.get('textarea#sro')
       .invoke('val')
-      .should('equal', 'ᐁᑏ ᓃᔭ, ᐁᑿ ᐆᐦᐆ ᓂᒌᐦᑫᔨᒫᐤ')
+      .should('contain', 'êtî nîya, êkwa ôhô nicîhkêyimâw.');
   });
 
   it.skip('should not affect pasted text');

--- a/cypress/integration/gh-008-double-vowels.js
+++ b/cypress/integration/gh-008-double-vowels.js
@@ -43,5 +43,28 @@ describe('Double typing for long vowels', function () {
       .should('contain', insertedText);
   });
 
-  it.skip('can be disabled');
+  it('can be disabled', function () {
+    cy.get('[data-cy="option-double-vowels"]').as('checkbox');
+    cy.get('textarea#sro').as('sro');
+
+    // With the checkbox enabled...
+    cy.get('@checkbox')
+      .check();
+    // ...there SHOULD be a change.
+    cy.get('@sro')
+      .clear()
+      .type('eetii')
+      .invoke('val')
+      .should('equal', 'êtî')
+
+    // However, when we uncheck the option...
+    cy.get('@checkbox')
+      .uncheck();
+    // ...there should be NO change in the long vowels:
+    cy.get('@sro')
+      .clear()
+      .type('eetii')
+      .invoke('val')
+      .should('equal', 'eetii')
+  });
 });

--- a/cypress/integration/gh-008-double-vowels.js
+++ b/cypress/integration/gh-008-double-vowels.js
@@ -47,6 +47,9 @@ describe('Double typing for long vowels', function () {
     cy.get('[data-cy="option-double-vowels"]').as('checkbox');
     cy.get('textarea#sro').as('sro');
 
+    cy.get('[data-cy="settings-drop-down"]')
+      .click();
+
     // With the checkbox enabled...
     cy.get('@checkbox')
       .check();

--- a/index.html
+++ b/index.html
@@ -59,10 +59,9 @@
         </fieldset>
       </details>
     </form>
-
   </main>
 
-  <footer>
+  <aside>
     <h2> What is this? </h2>
     <p> This is a <strong>standard Roman orthography (SRO)</strong>
     to <strong>syllabics</strong> converter for <strong>Cree</strong>
@@ -83,9 +82,20 @@
     <p> You can use circumflexes (âêîô) or macrons (āēīō). When
     converting from syllabics to SRO, you can choose which to produce in the
     <a href="#settings">settings</a>.
+  </aside>
 
-    <!-- true footer? -->
-    <p> cree-sro-syllabics <span id="library-version">unknown</span>.
+  <footer>
+    <ul class="meta">
+      <li>
+      <a href="https://www.npmjs.com/package/cree-sro-syllabics">
+          cree-sro-syllabics v<span id="library-version">unknown</span>
+      </a>
+      <li>
+      Made with ❤︎ by <a href="https://github.com/eddieantonio">Eddie Antonio Santos</a>
+      <li>
+      <a href="https://github.com/eddieantonio/syllabics.app">Open source</a>
+    </p>
+
     <script>
       document.getElementById('library-version').innerText = CREE_SRO_SYLLABICS_VERSION;
     </script>

--- a/index.html
+++ b/index.html
@@ -36,8 +36,8 @@
         <script>getDefaultTextareaValue('syl')</script>
       </div>
 
-      <details>
-        <summary id="settings" data-cy="settings-drop-down">
+      <details id="settings">
+        <summary data-cy="settings-drop-down">
           Settings
         </summary>
 
@@ -82,7 +82,7 @@
 
     <p> You can use circumflexes (âêîô) or macrons (āēīō). When
     converting from syllabics to SRO, you can choose which to produce in the
-    settings <a href="#settings">settings</a>.
+    <a href="#settings">settings</a>.
 
     <!-- true footer? -->
     <p> cree-sro-syllabics <span id="library-version">unknown</span>.

--- a/index.html
+++ b/index.html
@@ -52,7 +52,7 @@
           </label>
 
           <label>
-            <input type="checkbox" name="double-vowels" value="true" data-cy="option-double-vowels">
+            <input type="checkbox" name="double-vowels" checked data-cy="option-double-vowels">
             Type a vowel twice to type a long vowel (aa → â)
           </label>
         </fieldset>

--- a/index.html
+++ b/index.html
@@ -37,7 +37,9 @@
       </div>
 
       <details>
-        <summary data-cy="settings-drop-down">Settings</summary>
+        <summary id="settings" data-cy="settings-drop-down">
+          Settings
+        </summary>
 
         <fieldset class="extra-controls">
           <label>
@@ -65,23 +67,25 @@
     <p> This is a <strong>standard Roman orthography (SRO)</strong>
     to <strong>syllabics</strong> converter for <strong>Cree</strong>
     (N-dialect, Th-dialect, and Y-dialect).
-    Type the text you want to convert in the appropriately labelled box, and
-    the result should appear in the other box automatically as you type!  The
-    converter is bidirectional: it can go from SRO to syllabics and back
-    again. It supports both circumflexes (âêîô) and macrons (āēīō). It also
-    supports the special
-    <a href="https://crk-orthography.readthedocs.io/en/stable/glossary.html#term-sandhi">Sandhi orthographical rule</a>.
 
-    <p> Behind the scenes, this is a demo of the
-    <a href="https://www.npmjs.com/package/cree-sro-syllabics">cree-sro-syllabics JavaScript library</a>,
-    which is
-    <a href="https://opensource.com/resources/what-open-source">free and open source</a>,
-    and <a href="https://github.com/eddieantonio/cree-sro-syllabics.js">available on GitHub</a>.
-    You can use <code>npm</code> to install cree-sro-syllabics in your own JavaScript projects:
-    <code>npm install --save cree-sro-syllabics</code>
+    <h2> How to use the converter </h2>
 
-    <p>The version of the cree-sro-syllabics library on demo here is
-    <span id="library-version">unknown</span>.
+    <p> Type the text you want to convert in the appropriately labelled box, and
+    the result will appear in the other box instantly!
+
+    <p> The converter is <strong>bidirectional</strong>: it can go from SRO to
+    syllabics and back again.
+
+    <p> Typing a vowel <strong>twice</strong> in SRO (e.g., ee, ii, oo, aa)
+    will convert it into a long vowel (ê, î, ô, â). You can turn this off in
+    the <a href="#settings">settings</a>.
+
+    <p> You can use circumflexes (âêîô) or macrons (āēīō). When
+    converting from syllabics to SRO, you can choose which to produce in the
+    settings <a href="#settings">settings</a>.
+
+    <!-- true footer? -->
+    <p> cree-sro-syllabics <span id="library-version">unknown</span>.
     <script>
       document.getElementById('library-version').innerText = CREE_SRO_SYLLABICS_VERSION;
     </script>

--- a/index.html
+++ b/index.html
@@ -38,7 +38,7 @@
       </div>
 
       <details>
-        <summary>Settings</summary>
+        <summary data-cy="settings-drop-down">Settings</summary>
 
         <fieldset class="extra-controls">
           <label>
@@ -49,6 +49,11 @@
           <label>
             <input type="radio" name="macrons" value="true">
             Produce macrons (āēīō)
+          </label>
+
+          <label>
+            <input type="checkbox" name="double-vowels" value="true" data-cy="option-double-vowels">
+            Type a vowel twice to type a long vowel (aa → â)
           </label>
         </fieldset>
       </details>

--- a/main.js
+++ b/main.js
@@ -23,6 +23,7 @@
   document.addEventListener('DOMContentLoaded', function () {
     var sroBox = document.getElementById('sro');
     var sylBox = document.getElementById('syl');
+    var doubledVowelCheckbox = document.getElementsByName('double-vowels')[0];
     var macronButtons = document.getElementsByName('macrons');
     var previousSROText = sroBox.value;
 
@@ -40,6 +41,10 @@
       var addedChar;
       var commonPrefix;
       var newString;
+
+      if (!doubledVowelCheckbox.checked) {
+        return;
+      }
 
       // Check if exactly one character has been ADDED.
       // Only then can we check whether we want a long vowel.

--- a/main.js
+++ b/main.js
@@ -64,20 +64,6 @@
         lastVowel = null;
       }
 
-      function longVowelOf(vowel) {
-        if (vowel === 'e') {
-          return 'ê';
-        } else if (vowel === 'i') {
-          return 'î';
-        } else if (vowel === 'o') {
-          return 'ô';
-        } else if (vowel === 'a') {
-          return 'â'
-        } else {
-          throw new RangeError('Invalid long vowel: ' + vowel);
-        }
-      }
-    });
 
     // Send the appropriate request when the user types or pastes into the SRO
     // or syllabics boxes, respectively.
@@ -138,6 +124,22 @@
       // "ArrowRight", instead of a single character.
       return !event.key || event.key.length > 1;
     }
+
+    // Return the long version of a short vowel.
+    function longVowelOf(vowel) {
+      if (vowel === 'e') {
+        return 'ê';
+      } else if (vowel === 'i') {
+        return 'î';
+      } else if (vowel === 'o') {
+        return 'ô';
+      } else if (vowel === 'a') {
+        return 'â'
+      } else {
+        throw new RangeError('Invalid long vowel: ' + vowel);
+      }
+    }
+    });
   });
 
   window.getDefaultTextareaValue = function (name) {

--- a/main.js
+++ b/main.js
@@ -57,13 +57,13 @@
         // Reset state to before a vowel was pressed.
         lastVowel = null;
         return;
-      } else if (key === 'e' || key === 'i' || key === 'o' || key === 'a') {
+      } else if (isSROShortVowel(key)) {
         // Match vowels only
         lastVowel = key;
       } else {
         lastVowel = null;
       }
-
+    });
 
     // Send the appropriate request when the user types or pastes into the SRO
     // or syllabics boxes, respectively.
@@ -139,7 +139,10 @@
         throw new RangeError('Invalid long vowel: ' + vowel);
       }
     }
-    });
+
+    function isSROShortVowel(letter) {
+      return letter === 'e' || letter === 'i' || letter === 'o' || letter === 'a';
+    }
   });
 
   window.getDefaultTextareaValue = function (name) {

--- a/main.js
+++ b/main.js
@@ -42,6 +42,7 @@
       var commonPrefix;
       var newString;
 
+      // Obey settings on whether it should change.
       if (!doubledVowelCheckbox.checked) {
         return;
       }
@@ -107,6 +108,13 @@
 
     // Change the values when the /#!hash changes.
     window.onhashchange = function () {
+      var settingsBox;
+      // Open the settings box if navigated to.
+      if (location.hash === '#settings') {
+        settingsBox = document.getElementById('settings');
+        settingsBox.open = true;
+      }
+
       var pairs = parseFragment();
       updateBoxes(pairs);
       if ('sro' in pairs) {

--- a/styles.css
+++ b/styles.css
@@ -1,4 +1,4 @@
-/*
+/*!
  * This is free and unencumbered software released into the public domain.
  *
  * Anyone is free to copy, modify, publish, use, compile, sell, or
@@ -40,7 +40,7 @@ a {
     color: #0366d6;
 }
 
-footer {
+aside, footer {
     font-size: 9pt;
     color: #444;
 }
@@ -71,7 +71,7 @@ a > code {
     margin: 1rem auto;
 }
 
-main, footer {
+main, aside, footer {
     margin: 1rem;
 }
 
@@ -115,4 +115,24 @@ fieldset > label {
     .box textarea {
         min-height: 5.5ex;
     }
+}
+
+footer {
+    text-align: center;
+}
+
+ul.meta {
+    margin-left: 0;
+    padding-left: 0;
+    list-style: none;
+}
+
+
+ul.meta li {
+    display: inline-block;
+}
+
+ul.meta li:not(:first-child)::before {
+    content: " · ";
+    margin: auto .25em;
 }


### PR DESCRIPTION
I have a rudimentary version of this working, however it is quite fragile, and will likely be annoying to users.

Here are the issues I've encountered so far:

 - `InputEvent#data` is poorly supported in... almost everything
 - `KeyboardEvent` has a terrible API where almost everything is deprecated
 - Figuring out where in the `<textarea>` the text was modified is anoying without the full `InputEvent` API, which is lacking support in most browsers.

Idea: respond to the `InputEvent`. At least creating the input event is supported. Keep track of the prior and next version of the buffer. Diff the buffer, and determine if there's a single character change increment from the previous version of the buffer to the next; then determine if it's a change in vowel. Replace the vowel with the larger version.

Tasks remaining:

 - [x] document in UI

Closes #8.